### PR TITLE
Improve linting and iterate on includes.sh

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,4 +1,3 @@
----
 name: Check
 run-name: Checking on behalf of ${{ github.actor }}
 on: # yamllint disable-line rule:truthy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,4 +20,4 @@ jobs:
                   key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
                   restore-keys: ${{ runner.os }}-pre-commit-
             - run: pip install pip-tools && pip-sync
-            - run: set -x && source includes.sh && type pcam && pcam --color always --show-diff-on-failure
+            - run: source includes.sh && pcam --color always --show-diff-on-failure

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,9 +1,9 @@
----
 extends: default
 
 rules:
     comments:
         min-spaces-from-content: 1 # Unfortunate difference between prettier and black
+    document-start: disable
     indentation:
         spaces: 4
     line-length:

--- a/includes.sh
+++ b/includes.sh
@@ -8,7 +8,6 @@ case $(uname -s) in
         [[ -d /opt/homebrew/bin ]] && export PATH="/opt/homebrew/bin:$PATH"
         [[ -x $(command -v brew) ]] || echo ERROR: homebrew missing
     fi
-
 esac
 
 if ! [[ -x $(command -v nvm) ]]; then
@@ -56,6 +55,7 @@ a() {
         source .venv/bin/activate
         pathver python
     elif [[ -d conda ]]; then
+        # shellcheck disable=SC1091
         source "$HOME/miniconda3/etc/profile.d/conda.sh"
         conda activate "$(basename "$directory")"
         pathver python


### PR DESCRIPTION
- Don't warn about missing `---` YAML document starts, as these are only relevant for multi-document files, which are not currently used by any project I've worked on
- Drop `-x` tracing from GitHub Actions
- Configure `less` and `jq` in includes.sh
- Add `node` support to the `a` activate function for CDKTF
- Add `conda` support to the `a` activate function for Bokeh