### PR TITLE
Require exact match when expected version pins a bugfix

### DIFF
--- a/.biobuddies/includes.bash
+++ b/.biobuddies/includes.bash
@@ -100,7 +100,8 @@ pathver() {
     echo "$source $actual_version"
     if [[ -f $2 ]]; then
         expected_version=$(cat "$2")
-        if [[ $actual_version != "${expected_version%.*}".* ]]; then
+        if [[ $actual_version != "$expected_version" &&
+            ${actual_version%.*} != "$expected_version" ]]; then
             echo "ERROR: $source version $actual_version does not match $2 $expected_version"
             return 1
         fi

--- a/.biobuddies/justfile
+++ b/.biobuddies/justfile
@@ -26,7 +26,7 @@ pathver command version_file="":
     echo "$source $actual"
     if [[ -f "{{ version_file }}" ]]; then
         expected=$(cat "{{ version_file }}")
-        if [[ $actual != "${expected%.*}".* ]]; then
+        if [[ $actual != "$expected" && ${actual%.*} != "$expected" ]]; then
             echo "ERROR: $source version $actual does not match {{ version_file }} $expected"
             exit 1
         fi

--- a/{{cookiecutter.dot}}/.biobuddies/includes.bash
+++ b/{{cookiecutter.dot}}/.biobuddies/includes.bash
@@ -100,7 +100,8 @@ pathver() {
     echo "$source $actual_version"
     if [[ -f $2 ]]; then
         expected_version=$(cat "$2")
-        if [[ $actual_version != "${expected_version%.*}".* ]]; then
+        if [[ $actual_version != "$expected_version" &&
+            ${actual_version%.*} != "$expected_version" ]]; then
             echo "ERROR: $source version $actual_version does not match $2 $expected_version"
             return 1
         fi

--- a/{{cookiecutter.dot}}/.biobuddies/justfile
+++ b/{{cookiecutter.dot}}/.biobuddies/justfile
@@ -26,7 +26,7 @@ pathver command version_file="":
     echo "$source $actual"
     if [[ -f "{{ version_file }}" ]]; then
         expected=$(cat "{{ version_file }}")
-        if [[ $actual != "${expected%.*}".* ]]; then
+        if [[ $actual != "$expected" && ${actual%.*} != "$expected" ]]; then
             echo "ERROR: $source version $actual does not match {{ version_file }} $expected"
             exit 1
         fi


### PR DESCRIPTION
### Background and Links
* Addresses https://github.com/biobuddies/helicopyter/pull/71#discussion_r3529568153: `${expected%.*}.*` reduced an expected `3.14` to prefix `3`, wrongly matching `3.13.0`

### Changes and Testing
* `pathver` now passes only when the actual version equals the expected exactly, or the expected equals the actual with its bugfix component stripped: expected `3.14` allows any `3.14.x`, expected `3.14.2` matches only `3.14.2`, and expected `3` no longer matches every Python 3
* Applied to `.biobuddies/includes.bash`, `.biobuddies/justfile`, and both `{{cookiecutter.dot}}` copies
* Exercised with a fake command printing `3.14.1` against expected values `3.14` (pass), `3.14.1` (pass), `3.14.2` (fail), `3.13` (fail), `3` (fail)

### Questions and Followup
*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9Y8mhJZaSafjuXcNZ1Rbk

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9Y8mhJZaSafjuXcNZ1Rbk)_