### PR TITLE
Use POSIX `command -v`/`-V` in `pathver` for zsh and bash compat

### DIFF
--- a/.biobuddies/includes.bash
+++ b/.biobuddies/includes.bash
@@ -92,9 +92,13 @@ alias ls='ls --color=auto'
 
 pathver() {
     : 'print PATH and VERsion; optionally assert version file matches'
-    source=$(type -p "$1")
-    if [[ -z $source ]]; then
-        source=$(type "$1")
+    # Use POSIX command -v/-V so this function can be copied into a ~/.zshrc,
+    # as in cases where zsh aliases `type` to `whence -v`,
+    # which prints "python is /path" instead of "/path"
+    source=$(command -v "$1")
+    if [[ $source != /* ]]; then  # Not an absolute path (e.g. an alias or missing)
+        # We use 2>&1 because bash (unlike zsh) prints "not found" to stderr
+        source=$(command -V "$1" 2>&1)
     fi
     actual_version=$("$1" --version 2>&1 | gsed -En 's/(.+ )?(v?[0-9]+\.[0-9]+\.[^ ]+).*/\2/p')
     echo "$source $actual_version"

--- a/{{cookiecutter.dot}}/.biobuddies/includes.bash
+++ b/{{cookiecutter.dot}}/.biobuddies/includes.bash
@@ -92,9 +92,13 @@ alias ls='ls --color=auto'
 
 pathver() {
     : 'print PATH and VERsion; optionally assert version file matches'
-    source=$(type -p "$1")
-    if [[ -z $source ]]; then
-        source=$(type "$1")
+    # Use POSIX command -v/-V so this function can be copied into a ~/.zshrc,
+    # as in cases where zsh aliases `type` to `whence -v`,
+    # which prints "python is /path" instead of "/path"
+    source=$(command -v "$1")
+    if [[ $source != /* ]]; then  # Not an absolute path (e.g. an alias or missing)
+        # We use 2>&1 because bash (unlike zsh) prints "not found" to stderr
+        source=$(command -V "$1" 2>&1)
     fi
     actual_version=$("$1" --version 2>&1 | gsed -En 's/(.+ )?(v?[0-9]+\.[0-9]+\.[^ ]+).*/\2/p')
     echo "$source $actual_version"


### PR DESCRIPTION
### Background and Links

* `type -p` is a bashism: zsh aliases `type` to `whence -v`, whose output is never empty, leading to `pathver` in zsh printing "python is /path" instead of "/path"

### Changes and Testing

* Replaced the `type -p`/`type` fallback with `command -v`/`command -V 2>&1`; the `2>&1` additionally captures bash's stderr "not found" message, matching zsh's stdout behavior
* To compare old and new lookups, run the below in both `bash -c` and `zsh -c`:

  ```bash
  old() { source=$(type -p "$1"); [[ -z $source ]] && source=$(type "$1"); echo "old: [$source]"; }
  new() { source=$(command -v "$1"); [[ $source != /* ]] && source=$(command -V "$1" 2>&1); echo "new: [$source]"; }
  for name in python3 cd nonexistent_xyz; do old $name; new $name; done
  ```

  * zsh went from `python3 is /path` to `/path`, and from `cd is /usr/bin/cd` to `cd is a shell builtin`
  * bash was identical except a missing command's "not found" message now appears in `pathver`'s echoed output instead of only on stderr

### Questions and Followup

* Is having Zsh compat not worth worrying about here?